### PR TITLE
Avoid memory leak in `TableConfigure()`

### DIFF
--- a/generic/tkTable.c
+++ b/generic/tkTable.c
@@ -666,6 +666,9 @@ static int TableConfigure(
     result = Tk_ConfigureWidget(interp, tablePtr->tkwin, tableSpecs, objc, (void *) objv,
 	(char *) tablePtr, flags|TK_CONFIG_OBJS);
     if (result != TCL_OK) {
+	/* Free oldVar if it was allocated */
+	if (oldVar != NULL) ckfree(oldVar);
+
 	return TCL_ERROR;
     }
 


### PR DESCRIPTION
Currently, `oldVar` is leaked when a table widget configure error occurs.