### PR TITLE
Avoid out-of-bounds read during `tag raise` command

### DIFF
--- a/generic/tkTableTag.c
+++ b/generic/tkTableTag.c
@@ -1214,10 +1214,11 @@ int Table_TagCmd(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *c
 		    goto invalidtag;
 		}
 		tag2Ptr  = (TableTag *) Tcl_GetHashValue(entryPtr);
-		if (cmdIndex == TAG_LOWER) {
-		    value = TableTagGetPriority(tablePtr, tag2Ptr);
-		} else {
-		    value = TableTagGetPriority(tablePtr, tag2Ptr) - 1;
+		value = TableTagGetPriority(tablePtr, tag2Ptr);
+		if (cmdIndex == TAG_LOWER && value < tagPrio) {
+		    value++;
+		} else if (cmdIndex == TAG_RAISE && value > tagPrio) {
+		    value--;
 		}
 	    } else {
 		if (cmdIndex == TAG_LOWER) {
@@ -1229,7 +1230,7 @@ int Table_TagCmd(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *c
 		    /*
 		     * Raise this tag's priority to the top.
 		     */
-		    value = -1;
+		    value = 0;
 		}
 	    }
 	    if (value < tagPrio) {
@@ -1240,7 +1241,6 @@ int Table_TagCmd(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *c
 		    tablePtr->tagPrioNames[i] = tablePtr->tagPrioNames[i-1];
 		    tablePtr->tagPrios[i]     = tablePtr->tagPrios[i-1];
 		}
-		i++;
 		tablePtr->tagPrioNames[i] = keybuf;
 		tablePtr->tagPrios[i]     = tagPtr;
 		refresh = 1;


### PR DESCRIPTION
The widget command `$table tag raise foo`, such as the one in test table-25.2.7, triggers a buffer over-read. ASan (AddressSanitizer) output for Tcl/Tk built with `-DPURIFY -fsanitize=address`:

```
==21912==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x611000393cb8 at pc 0x00011971aa6e bp 0x7ff7bfefa6b0 sp 0x7ff7bfefa6a8
READ of size 8 at 0x611000393cb8 thread T0
    #0 0x00011971aa6d in Table_TagCmd tkTableTag.c:1240
    #1 0x0001196cdd22 in TableWidgetObjCmd tkTable.c:1091
    #2 0x0001019bde8c in Dispatch tclBasic.c:4643
    #3 0x0001019a016c in TclNRRunCallbacks tclBasic.c:4659
    #4 0x00010199e7fd in Tcl_EvalObjv tclBasic.c:4397
    #5 0x0001019ab6d7 in TclEvalEx tclBasic.c:5498
    #6 0x0001023536fe in Tcl_FSEvalFileEx tclIOUtil.c:1793
    #7 0x0001023d8d21 in Tcl_MainEx tclMain.c:404
    #8 0x000100001e2c in main tclAppInit.c:98
    #9 0x7ff80fed552f in start+0xbef (dyld:x86_64+0xfffffffffffde52f)

0x611000393cb8 is located 8 bytes before 240-byte region [0x611000393cc0,0x611000393db0)
allocated by thread T0 here:
    #0 0x00010050cb22 in malloc+0x82 (libclang_rt.asan_osx_dynamic.dylib:x86_64h+0x9db22)
    #1 0x000101930d9c in TclpAlloc tclAlloc.c:700
    #2 0x000101a143ec in Tcl_Alloc tclCkalloc.c:1035
    #3 0x0001196c2465 in Tk_TableObjCmd tkTable.c:1720
    #4 0x0001019bde8c in Dispatch tclBasic.c:4643
    #5 0x0001019a016c in TclNRRunCallbacks tclBasic.c:4659
    #6 0x00010199e7fd in Tcl_EvalObjv tclBasic.c:4397
    #7 0x0001019ab6d7 in TclEvalEx tclBasic.c:5498
    #8 0x0001023536fe in Tcl_FSEvalFileEx tclIOUtil.c:1793
    #9 0x0001023d8d21 in Tcl_MainEx tclMain.c:404
    #10 0x000100001e2c in main tclAppInit.c:98
    #11 0x7ff80fed552f in start+0xbef (dyld:x86_64+0xfffffffffffde52f)

SUMMARY: AddressSanitizer: heap-buffer-overflow tkTableTag.c:1240 in Table_TagCmd
```

Raising a tag to priority 0 causes `value` to be set to -1 which eventually causes out-of-bounds reads from `tablePtr->tagPrioNames[-1]` and `tablePtr->tagPrios[-1]` in the `for` loop.

I hope it makes sense how the proposed change avoids this issue. Mainly it is to keep `value` and `i-1` at or above 0 and consistently use `value` as the "destination" priority.